### PR TITLE
Prioritize #value over #keywords

### DIFF
--- a/syntaxes/surrealql.tmLanguage.json
+++ b/syntaxes/surrealql.tmLanguage.json
@@ -19,13 +19,13 @@
 			"include": "#function"
 		},
 		{
-			"include": "#keywords"
-		},
-		{
 			"include": "#operators"
 		},
 		{
 			"include": "#value"
+		},
+		{
+			"include": "#keywords"
 		}
 	],
 	"repository": {


### PR DESCRIPTION
I'm in the process of integrating the grammar into Surrealist however the order in which patterns are defined is causing issues

Before:
![image](https://github.com/surrealdb/surrealql-grammar/assets/7606171/eb61d67c-aca5-4448-8e95-7a938261d177)

After:
![image](https://github.com/surrealdb/surrealql-grammar/assets/7606171/0952b429-ff45-44bc-a94a-d7392a472a4f)
