### PR TITLE
Add support for Rust raw strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.surrealql": "surrealql"
         }
+      },
+      {
+        "injectTo": [
+          "source.rust"
+        ],
+        "scopeName": "inline.surrealql-rs-string",
+        "path": "./syntaxes/surrealql-rs-string.tmLanguage.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.surrealql": "surrealql"
+        }
       }
     ],
     "snippets": [

--- a/syntaxes/surrealql-rs-string.tmLanguage.json
+++ b/syntaxes/surrealql-rs-string.tmLanguage.json
@@ -1,0 +1,44 @@
+{
+  "scopeName": "inline.surrealql-rs-string",
+  "fileTypes": ["rs"],
+  "injectionSelector": ["L:source -comment -string"],
+  "patterns": [
+    {
+      "include": "#sql-rs-string-comment"
+    }
+  ],
+  "repository": {
+    "sql-rs-string-comment": {
+      "name": "meta.embedded.block.surrealql",
+      "begin": "(b?r)(#*)(\")(--\\s*(surql|surrealql))",
+      "end": "(\")(\\2)",
+      "beginCaptures": {
+        "1": {
+          "name": "string.quoted.byte.raw.rust"
+        },
+        "2": {
+          "name": "string.raw.rust"
+        },
+        "3": {
+          "name": "string.rust"
+        },
+        "4": {
+          "name": "comment.sql"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "string.rust"
+        },
+        "2": {
+          "name": "string.raw.rust"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.surrealql"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Will match the following in .rs files:

```rust
let query = r#"--surrealql
    SELECT * FROM type::table($table);
"#;
```

or alternatively:

```rust
let query = r#"--surql
    SELECT * FROM type::table($table);
"#;
```

I have no idea what I am doing, but it works 😄