### PR TITLE
allow syntax highlighting inside surql / surrealql function

### DIFF
--- a/syntaxes/surrealql-js-literal.tmLanguage.json
+++ b/syntaxes/surrealql-js-literal.tmLanguage.json
@@ -5,6 +5,9 @@
   "patterns": [
     {
       "include": "#sql-template-literal"
+    },
+    {
+      "include": "#sql-function-call"
     }
   ],
   "repository": {
@@ -48,6 +51,41 @@
         },
         {
           "include": "source.surrealql"
+        }
+      ]
+    },
+    "sql-function-call": {
+      "name": "meta.embedded.surrealql.call",
+      "begin": "(?:(surql|surrealql)|(\\/\\*\\s*(?:surql|surrealql)\\s*\\*\\/))\\s*(\\.[_$[:alpha:]][_$[:alnum:]]*)?\\s*(<.+>)?\\(\\s*(?=[\"'`])",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.js"
+        },
+        "2": {
+          "name": "comment.block.js"
+        }
+      },
+      "end": "\\)",
+      "patterns": [
+        {
+          "name": "string.quoted.surrealql",
+          "begin": "([\"'`])",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.js"
+            }
+          },
+          "end": "\\1",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.js"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.surrealql"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Allows syntax highlight inside `surql()` and `surrealql()` functions as alternative to the already supported `surql` and `surrealql` tagged template literals.

Currently the type of tagged template literal function arguments cannot be inferred in typescript. With the support of functions we allow future development of e.g. automatic code inference or other typescript magic.